### PR TITLE
Fix some file troubles with Mono

### DIFF
--- a/Game.cs
+++ b/Game.cs
@@ -369,10 +369,13 @@ namespace Noxico
 			Program.WriteLine("Preloading book info...");
 			BookTitles = new Dictionary<string, string[]>();
 			//Use GetFilesWithPattern to allow books in mission folders -- /missions/homestuck/books/legendbullshit.txt
-			foreach (var book in Mix.GetFilesWithPattern("\\books\\*.txt"))
+			foreach (var book in Mix.GetFilesWithPattern("(^|\\|/)books(\\|/)*.txt"))
 			{
 				var bookFile = Mix.GetString(book, false).Split('\n');
-				var bookID = Path.GetFileNameWithoutExtension(book);
+				var bookExt = book;
+				if (Environment.OSVersion.Platform == PlatformID.Unix)
+					bookExt = bookExt.Replace("\\", "/");
+				var bookID = Path.GetFileNameWithoutExtension(bookExt);
 				var bookName = bookFile[0].Substring(3).Trim();
 				var bookAuthor = bookFile[1].StartsWith("## ") ? bookFile[1].Substring(3).Trim() : i18n.GetString("book_unknownauthor");
 				BookTitles.Add(bookID, new[] { bookName, bookAuthor });

--- a/Subscreens/Options.cs
+++ b/Subscreens/Options.cs
@@ -50,7 +50,12 @@ namespace Noxico
 				};
 				speed.Move(1, 1, speedLabel);
 
-				var fonts = Mix.GetFilesWithPattern("fonts\\*.png").Select(x => System.IO.Path.GetFileNameWithoutExtension(x)).ToArray();
+				var fontsExt = Mix.GetFilesWithPattern("fonts\\*.png");
+				string[] fonts;
+				if (NoxicoGame.Mono)
+					fonts = fontsExt.Select(x => System.IO.Path.GetFileNameWithoutExtension(x.Replace("\\", "/"))).ToArray();
+				else
+					fonts = fontsExt.Select(x => System.IO.Path.GetFileNameWithoutExtension(x)).ToArray();
 				var currentFont = IniFile.GetValue("misc", "font", "8x8-thin");
 				var currentFontIndex = 0;
 				if (fonts.Contains(currentFont))


### PR DESCRIPTION
Slash inconsistency made book files fail to load and font settings fail to apply correctly on Unix systems. This sprinkles a few conditionals and regex tweaks around to ungunk the gears.